### PR TITLE
Updated the code sample for replacing minimum gas prices to match the…

### DIFF
--- a/bombay-9/README.md
+++ b/bombay-9/README.md
@@ -43,7 +43,7 @@ go: go version go1.16.5 darwin/amd64
 $ terrad init [moniker] --chain-id bombay-9
 $ wget https://raw.githubusercontent.com/terra-money/testnet/master/bombay-9/genesis.json
 $ cp genesis.json ~/.terra/config/genesis.json
-$ sed -i 's/minimum-gas-prices = ""/minimum-gas-prices = "0.15uluna,0.1018usdr,0.15uusd,178.05ukrw,431.6259umnt,0.125ueur,0.97ucny,16.0ujpy,0.11ugbp,11.0uinr,0.19ucad,0.13uchf,0.19uaud,0.2usgd,4.62uthb,1.25usek,1.164uhkd,0.9udkk,1.25unok"/g' ~/.terra/config/app.toml
+$ sed -i 's/minimum-gas-prices = "0uluna"/minimum-gas-prices = "0.15uluna,0.1018usdr,0.15uusd,178.05ukrw,431.6259umnt,0.125ueur,0.97ucny,16.0ujpy,0.11ugbp,11.0uinr,0.19ucad,0.13uchf,0.19uaud,0.2usgd,4.62uthb,1.25usek,1.164uhkd,0.9udkk,1.25unok"/g' ~/.terra/config/app.toml
 $ terrad start
 ```
 


### PR DESCRIPTION
… default value from v0.5.0 of core.

The default value for `minimum-gas-prices` in version 0.5.0 of Terra core now has `0uluna` as its value. The original sed command will fail because of this. This PR fixes that.