### PR TITLE
Updated correct height in export section

### DIFF
--- a/bombay-11/README.md
+++ b/bombay-11/README.md
@@ -11,7 +11,7 @@ Testnet for Columbus-5.
 Export requires at least 16GB memory
 ```shell
 # terrad@v0.4.6
-$ terrad export --height 5330000 > exported-genesis.json
+$ terrad export --height 5900000 > exported-genesis.json
 $ jq -S -c -M "" ./exported-genesis.json| shasum -a 256 
 afa5a8077272f377e8e71b55b24409ea5469fc2ee5ab8c593c032f257f8b7f08 ./exported-genesis.json
 ```


### PR DESCRIPTION
@YunSuk-Yeo 
I think there was height mismatch in instructions at export genesis section.. 
exported genesis hash could be with correct height.

so updated only height