### PR TITLE
Update README.md oracle link

### DIFF
--- a/bombay-12/README.md
+++ b/bombay-12/README.md
@@ -72,7 +72,7 @@ e6be82b4a659964fad27ee14f844c222fe9abadf@104.197.21.152:26656
 * `$ terracli rest-server` removed, instead you can activate rest-server on `~/.terra/config/app.toml` by setting `enable = true` on `[api]` section.
 * Swagger url changed to `:1317/swagger-ui/` to `:1317/swagger/`
 * Please use `bombay` branch ecosystem tools
-   - oracle feeder https://github.com/terra-money/oracle-feeder/tree/bombay 
+   - oracle feeder v2.0.0: https://github.com/terra-money/oracle-feeder/releases/tag/v2.0.0 
    - terra.js (`$ npm i -S @terra-money/terra.js@^2`)
 
 


### PR DESCRIPTION
Broken link: https://github.com/terra-money/testnet/tree/master/bombay-12

Bombay branch is no longer active. 

Link changed to https://github.com/terra-money/oracle-feeder/releases/tag/v2.0.0